### PR TITLE
Added warning regarding app generation

### DIFF
--- a/src/integrations/does-outsystems-support-cocoapods/faq.md
+++ b/src/integrations/does-outsystems-support-cocoapods/faq.md
@@ -41,6 +41,8 @@ If you're curious and want to know if your plugin uses CocoaPods, follow the ste
 
 1. Open the plugin.xml file and search for podspec framework (check [this example](https://github.com/phonegap/phonegap-plugin-push/blob/v2.0.0/plugin.xml#L87 "https://github.com/phonegap/phonegap-plugin-push/blob/v2.0.0/plugin.xml#L87")).
 
-<div class="info" markdown="1">
-Make sure that the podspec framework version is correct in the plugin.xml file, or your app generation will fail.
-</div>
+    <div class="info" markdown="1">
+    
+    To generate the app successfully, make sure that the podspec framework version is correct in the plugin.xml.
+    
+    </div>

--- a/src/integrations/does-outsystems-support-cocoapods/faq.md
+++ b/src/integrations/does-outsystems-support-cocoapods/faq.md
@@ -40,3 +40,7 @@ If you're curious and want to know if your plugin uses CocoaPods, follow the ste
     ![](images/github-plugin-xml-file.png)
 
 1. Open the plugin.xml file and search for podspec framework (check [this example](https://github.com/phonegap/phonegap-plugin-push/blob/v2.0.0/plugin.xml#L87 "https://github.com/phonegap/phonegap-plugin-push/blob/v2.0.0/plugin.xml#L87")).
+
+<div class="info" markdown="1">
+Make sure that the podspec framework version is correct in the plugin.xml file, or your app generation will fail.
+</div>


### PR DESCRIPTION
As per ticket #2430396, a customer inserted the wrong version of a podspec framework, causing the app generation to fail. This warning will make sure that both customers and L1 will make sure that this does not happen again.